### PR TITLE
Use unified diff for build warning output

### DIFF
--- a/tests/patch/build_32bit/build_32bit.sh
+++ b/tests/patch/build_32bit/build_32bit.sh
@@ -52,7 +52,7 @@ if [ $current -gt $incumbent ]; then
   grep -i "\(warn\|error\)" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
     > $tmpfile_fn
 
-  diff $tmpfile_fo $tmpfile_fn 1>&2
+  diff -U 0 $tmpfile_fo $tmpfile_fn 1>&2
   rm $tmpfile_fo $tmpfile_fn
 
   rc=1

--- a/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
+++ b/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
@@ -52,7 +52,7 @@ if [ $current -gt $incumbent ]; then
   grep -i "\(warn\|error\)" $tmpfile_n | sed -n 's@\(^\.\./[/a-zA-Z0-9_.-]*.[ch]\):.*@\1@p' | sort | uniq -c \
     > $tmpfile_fn
 
-  diff $tmpfile_fo $tmpfile_fn 1>&2
+  diff -U 0 $tmpfile_fo $tmpfile_fn 1>&2
   rm $tmpfile_fo $tmpfile_fn
 
   rc=1


### PR DESCRIPTION
Update build_allmodconfig_warn and build_32bit to use "diff -u" output.