### PR TITLE
core: Use arrays instead of shell strings for subprocess

### DIFF
--- a/core/cmd.py
+++ b/core/cmd.py
@@ -35,7 +35,7 @@ class CmdError(Exception):
         self.stderr = stderr
 
 
-def cmd_run(cmd, shell=True, include_stderr=False, add_env=None, cwd=None,
+def cmd_run(cmd: list[str], shell=False, include_stderr=False, add_env=None, cwd=None,
             pass_fds=()):
     """Run a command.
 
@@ -44,8 +44,8 @@ def cmd_run(cmd, shell=True, include_stderr=False, add_env=None, cwd=None,
 
     Parameters
     ----------
-    cmd : str
-        shell command with all its arguments
+    cmd : array of str
+        command to run with all its arguments
     shell : bool, optional
         invoke command in a full shell
     include_stderr : bool, optional

--- a/core/test.py
+++ b/core/test.py
@@ -34,6 +34,11 @@ class Test(object):
                                         (test_group, name,
                                          self.info["pymod"]))
             self._exec_pyfunc = getattr(m, self.info["pyfunc"])
+        if "run" in self.info:
+            # If the test to run is not a fully qualified path, add the
+            # test directory to make it so.
+            if self.info["run"][0][0] != '/':
+                self.info["run"][0] = os.path.join(self.path, self.info["run"][0])
         core.log_end_sec()
 
     def _info_load(self):
@@ -112,7 +117,7 @@ class Test(object):
         try:
             rfd, wfd = os.pipe()
 
-            out, err = CMD.cmd_run(os.path.join(self.path, self.info["run"]),
+            out, err = CMD.cmd_run(self.info["run"],
                                    include_stderr=True, cwd=tree.path, pass_fds=[wfd],
                                    add_env={"DESC_FD": str(wfd)})
         except core.cmd.CmdError as e:

--- a/tests/patch/build_32bit/info.json
+++ b/tests/patch/build_32bit/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "build_32bit.sh"
+  "run": ["build_32bit.sh"]
 }

--- a/tests/patch/build_allmodconfig_warn/info.json
+++ b/tests/patch/build_allmodconfig_warn/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "build_allmodconfig.sh"
+  "run": ["build_allmodconfig.sh"]
 }

--- a/tests/patch/cc_maintainers/test.py
+++ b/tests/patch/cc_maintainers/test.py
@@ -48,7 +48,7 @@ def cc_maintainers(tree, thing, result_dir) -> Tuple[int, str]:
     ignored = set()
     with tempfile.NamedTemporaryFile() as fp:
         patch.write_out(fp)
-        command = ['./scripts/get_maintainer.pl', fp.name]
+        command = ['./scripts/get_maintainer.pl', '--', fp.name]
         with subprocess.Popen(command, cwd=tree.path, stdout=subprocess.PIPE) as p:
             line = p.stdout.readline().decode('utf8', 'replace')
             while line:

--- a/tests/patch/checkpatch/info.json
+++ b/tests/patch/checkpatch/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "checkpatch.sh"
+  "run": ["checkpatch.sh"]
 }

--- a/tests/patch/header_inline/info.json
+++ b/tests/patch/header_inline/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "header_inline.sh"
+  "run": ["header_inline.sh"]
 }

--- a/tests/patch/kdoc/info.json
+++ b/tests/patch/kdoc/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "kdoc.sh"
+  "run": ["kdoc.sh"]
 }

--- a/tests/patch/maintainers/info.json
+++ b/tests/patch/maintainers/info.json
@@ -1,4 +1,4 @@
 {
-  "run": "maintainers.sh",
+  "run": ["maintainers.sh"],
   "disabled": true
 }

--- a/tests/patch/module_param/info.json
+++ b/tests/patch/module_param/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "module_param.sh"
+  "run": ["module_param.sh"]
 }

--- a/tests/patch/source_inline/info.json
+++ b/tests/patch/source_inline/info.json
@@ -1,3 +1,3 @@
 {
-  "run": "source_inline.sh"
+  "run": ["source_inline.sh"]
 }

--- a/tests/patch/verify_fixes/info.json
+++ b/tests/patch/verify_fixes/info.json
@@ -1,4 +1,4 @@
 {
   "source": "https://raw.githubusercontent.com/gregkh/gregkh-linux/master/work/verify_fixes.sh",
-  "run": "verify_fixes.sh HEAD~..HEAD"
+  "run": ["verify_fixes.sh", "HEAD~..HEAD"]
 }

--- a/tests/patch/verify_signedoff/info.json
+++ b/tests/patch/verify_signedoff/info.json
@@ -1,4 +1,4 @@
 {
   "source": "https://raw.githubusercontent.com/gregkh/gregkh-linux/master/work/verify_signedoff.sh",
-  "run": "verify_signedoff.sh HEAD~..HEAD"
+  "run": ["verify_signedoff.sh", "HEAD~..HEAD"]
 }


### PR DESCRIPTION
Instead of needing to constantly worry about shell escapes and other
side-effects, always run commands with explicit argument arrays, and
terminate any option lists before adding non-option arguments.

Signed-off-by: Kees Cook <keescook@chromium.org>
---
I don't have my own PW to test this against, so this was done a bit
blind, though the python is all syntax-correct. :)