### PR TITLE
Test: unconditionally add line ending

### DIFF
--- a/core/test.py
+++ b/core/test.py
@@ -58,6 +58,8 @@ class Test(object):
             with open(os.path.join(test_dir, "stderr"), "w+") as fp:
                 fp.write(err)
         if desc:
+            if not desc.endswith('\n'):
+                desc += '\n'
             with open(os.path.join(test_dir, "desc"), "w+") as fp:
                 fp.write(desc)
         with open(os.path.join(test_dir, "summary"), "w+") as fp:


### PR DESCRIPTION
For python tests that return a "desc" without a trailing newline, the
"desc" file ends up without a trailing newline. This looks weird when
examining files from the command-line, so make sure it doesn't happen
any more.

Signed-off-by: Kees Cook <keescook@chromium.org>