### PR TITLE
tests/patch/build_*: Report CC version

### DIFF
--- a/tests/patch/build_32bit/build_32bit.sh
+++ b/tests/patch/build_32bit/build_32bit.sh
@@ -16,7 +16,9 @@ prep_config() {
   ./scripts/config --file $output_dir/.config -d werror
 }
 
-echo "Using -j $ncpu redirect to $tmpfile_o and $tmpfile_n"
+echo "Using $build_flags redirect to $tmpfile_o and $tmpfile_n"
+echo "CC=$cc"
+"$cc" --version | head -n1
 
 HEAD=$(git rev-parse HEAD)
 

--- a/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
+++ b/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
@@ -16,7 +16,9 @@ prep_config() {
   ./scripts/config --file $output_dir/.config -d werror
 }
 
-echo "Using -j $ncpu redirect to $tmpfile_o and $tmpfile_n"
+echo "Using $build_flags redirect to $tmpfile_o and $tmpfile_n"
+echo "CC=$cc"
+"$cc" --version | head -n1
 
 HEAD=$(git rev-parse HEAD)
 

--- a/tests/patch/build_clang/build_clang.sh
+++ b/tests/patch/build_clang/build_clang.sh
@@ -16,7 +16,9 @@ prep_config() {
   ./scripts/config --file $output_dir/.config -d werror
 }
 
-echo "Using -j $ncpu redirect to $tmpfile_o and $tmpfile_n"
+echo "Using $build_flags redirect to $tmpfile_o and $tmpfile_n"
+echo "CC=$cc"
+"$cc" --version | head -n1
 
 HEAD=$(git rev-parse HEAD)
 


### PR DESCRIPTION
It can frequently helpful to know exactly which compiler version was
used for a test build. Report the version (and all build flags).

Signed-off-by: Kees Cook <keescook@chromium.org>