### PR TITLE
tester: fix tests.include handling

### DIFF
--- a/core/tester.py
+++ b/core/tester.py
@@ -15,7 +15,10 @@ from core import Test, PullError
 def load_tests(config, name):
     core.log_open_sec(name.capitalize() + " tests")
     tests_subdir = os.path.join(config.get('dirs', 'tests'), name)
-    include = [x.strip() for x in config.get('tests', 'include', fallback="").split(',')]
+    try:
+        include = [x.strip() for x in config.get('tests', 'include').split(',')]
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        include = []
     exclude = [x.strip() for x in config.get('tests', 'exclude', fallback="").split(',')]
     tests = []
     for td in os.listdir(tests_subdir):


### PR DESCRIPTION
Empty string split by ',' will be an array with a single
element. i.e. ['']. The code later on tests if len(include) == 0
For that to work we need an empty array.

Signed-off-by: Jakub Kicinski <kuba@kernel.org>