### PR TITLE
tests: add a script to check if new selftest in Makefile

### DIFF
--- a/tests/patch/check_selftest/check_selftest.sh
+++ b/tests/patch/check_selftest/check_selftest.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Check if the shell selftest scripts are in correspond Makefile
+
+rt=0
+
+files=$(git show --pretty="" --name-only -- tools/testing/selftests*.sh)
+if [ -z "$files" ]; then
+	echo "No net selftest shell script" >&$DESC_FD
+	exit $rt
+fi
+
+for file in $files; do
+	f=$(basename $file)
+	d=$(dirname $file)
+	if [ -f "${d}/Makefile" ] && ! grep -P "[\t| ]${f}" ${d}/Makefile; then
+		echo "Script ${f} not found in ${d}/Makefile" >&$DESC_FD
+		rt=1
+	fi
+done
+
+[ ${rt} -eq 0 ] && echo "net selftest script(s) already in Makefile" >&$DESC_FD
+
+exit $rt

--- a/tests/patch/check_selftest/info.json
+++ b/tests/patch/check_selftest/info.json
@@ -1,0 +1,3 @@
+{
+  "run": ["check_selftest.sh"]
+}


### PR DESCRIPTION
As there are always some developers forget to add new selftests
in Makefile, which will make the test missing during installation.

Add a script to check if the new selftests are in correspond
Makefile or not.

Here are the example output:

##
check_selftest - OKAY
No net selftest shell script
##
check_selftest - OKAY
net selftest script(s) already in Makefile
##
check_selftest - FAILED
Script test.sh not found in tools/testing/selftests/net/Makefile

Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>