### PR TITLE
Fix "ccache gcc" command not found messages

### DIFF
--- a/tests/patch/build_32bit/build_32bit.sh
+++ b/tests/patch/build_32bit/build_32bit.sh
@@ -18,7 +18,7 @@ prep_config() {
 
 echo "Using $build_flags redirect to $tmpfile_o and $tmpfile_n"
 echo "CC=$cc"
-"$cc" --version | head -n1
+$cc --version | head -n1
 
 HEAD=$(git rev-parse HEAD)
 

--- a/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
+++ b/tests/patch/build_allmodconfig_warn/build_allmodconfig.sh
@@ -18,7 +18,7 @@ prep_config() {
 
 echo "Using $build_flags redirect to $tmpfile_o and $tmpfile_n"
 echo "CC=$cc"
-"$cc" --version | head -n1
+$cc --version | head -n1
 
 HEAD=$(git rev-parse HEAD)
 

--- a/tests/patch/build_clang/build_clang.sh
+++ b/tests/patch/build_clang/build_clang.sh
@@ -18,7 +18,7 @@ prep_config() {
 
 echo "Using $build_flags redirect to $tmpfile_o and $tmpfile_n"
 echo "CC=$cc"
-"$cc" --version | head -n1
+$cc --version | head -n1
 
 HEAD=$(git rev-parse HEAD)
 


### PR DESCRIPTION
The erroneous extra quoting causes the shell to search for an executable with a space, that obviously doesn't exist.

What we actually mean here is to run the whole "ccache gcc --version" command and parse all 2 spaces, which can be achieved by just removing the quote.

Example error at: https://patchwork.hopto.org/static/nipa/713686/13108014/build_32bit/stderr